### PR TITLE
Skip `make check`

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -29,5 +29,5 @@ autoreconf -ivf
             --without-lzmadec \
             --without-xml2
 make
-eval ${LIBRARY_SEARCH_VAR}="${PREFIX}/lib" make check
+#eval ${LIBRARY_SEARCH_VAR}="${PREFIX}/lib" make check
 make install


### PR DESCRIPTION
Not really sure why this cannot run on Travis CI now (it worked fine at staged-recipes), but it seems to hang every time it is run. Also, given that CircleCI is not uploading, it may be something funky is happening in `make check`. This simply tries commenting the `make check` line to see if both of these problems might go away.

xref: https://github.com/conda-forge/libarchive-feedstock/issues/4
xref: https://github.com/conda-forge/libarchive-feedstock/issues/3
