### PR TITLE
WIP: Readd `make check`

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -29,5 +29,5 @@ autoreconf -ivf
             --without-lzmadec \
             --without-xml2
 make
-#eval ${LIBRARY_SEARCH_VAR}="${PREFIX}/lib" make check
+eval ${LIBRARY_SEARCH_VAR}="${PREFIX}/lib" make check
 make install


### PR DESCRIPTION
Reverts PR ( https://github.com/conda-forge/libarchive-feedstock/pull/5 ) so that `make check` is being run again. There is probably more work required than a simple reversion, but this at least queues up that change and keeps it on the radar.
