### PR TITLE
Unpin conda-build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ install:
 
       conda config --set show_channel_urls true
       conda update --yes conda
-      conda install --yes conda-build=1.20.0 jinja2 anaconda-client
+      conda install --yes conda-build jinja2 anaconda-client
       conda config --add channels conda-forge
       
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: bcefe75f3f1527656c82e42e7adf1614ae274d005b2583d0ae15f857bfb1ed28
 
 build:
-  number: 0
+  number: 1
   skip: true  # [win]
 
 requirements:


### PR DESCRIPTION
See this issue ( https://github.com/conda-forge/hdf5-feedstock/issues/23 ) for a longer discussion. Basically, `conda-build` is packaging components added by `conda`/`conda-env` resulted in broken packages shipped. This is really a product of mismatched versions. So, we unpin `conda-build` to resolve this issue.
