### PR TITLE
Activate export env

### DIFF
--- a/recipe/activate.sh
+++ b/recipe/activate.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+if [ "`uname`" == 'Darwin' ]
+then
+    # for Mac OSX
+    export LIBARCHIVE="${PREFIX}/lib/libarchive.dylib"
+else
+    # for Linux
+    export LIBARCHIVE="${PREFIX}/lib/libarchive.so"
+fi

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -37,5 +37,5 @@ make install
 for CHANGE in "activate" "deactivate"
 do
     mkdir -p "${PREFIX}/etc/conda/${CHANGE}.d"
-    cp "${RECIPE_DIR}/${CHANGE}.sh" "${PREFIX}/etc/conda/${CHANGE}.d/toolchain_${CHANGE}.sh"
+    cp "${RECIPE_DIR}/${CHANGE}.sh" "${PREFIX}/etc/conda/${CHANGE}.d/libarchive.sh"
 done

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -37,5 +37,5 @@ make install
 for CHANGE in "activate" "deactivate"
 do
     mkdir -p "${PREFIX}/etc/conda/${CHANGE}.d"
-    cp "${RECIPE_DIR}/${CHANGE}.sh" "${PREFIX}/etc/conda/${CHANGE}.d/libarchive.sh"
+    cp "${RECIPE_DIR}/${CHANGE}.sh" "${PREFIX}/etc/conda/${CHANGE}.d/libarchive_${CHANGE}.sh"
 done

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -28,6 +28,14 @@ autoreconf -ivf
             --without-lz4 \
             --without-lzmadec \
             --without-xml2
-make
+make -j${NUM_CPUS}
 #eval ${LIBRARY_SEARCH_VAR}="${PREFIX}/lib" make check
 make install
+
+# Copy the [de]activate scripts to $PREFIX/etc/conda/[de]activate.d.
+# This will allow them to be run on environment activation.
+for CHANGE in "activate" "deactivate"
+do
+    mkdir -p "${PREFIX}/etc/conda/${CHANGE}.d"
+    cp "${RECIPE_DIR}/${CHANGE}.sh" "${PREFIX}/etc/conda/${CHANGE}.d/toolchain_${CHANGE}.sh"
+done

--- a/recipe/deactivate.sh
+++ b/recipe/deactivate.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+unset LIBARCHIVE

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: bcefe75f3f1527656c82e42e7adf1614ae274d005b2583d0ae15f857bfb1ed28
 
 build:
-  number: 2
+  number: 3
   skip: true  # [win]
 
 requirements:
@@ -53,6 +53,9 @@ test:
     - bsdcat --version
     - bsdcpio --version
     - bsdtar --version
+
+    # Verify exported environment variable.
+    - if [[ -z "${LIBARCHIVE}" ]]; then exit 1; fi
 
 about:
   home: http://www.libarchive.org/


### PR DESCRIPTION
This adds activate/deactivate scripts for [downstreams](https://github.com/Changaco/python-libarchive-c) that will be expecting `$LIBARCHIVE` to find the .so/.dylib.