### PR TITLE
MNT: Re-rendered with conda-build 3.17.8, conda-smithy 3.3.4, and conda-forge-pinning 2019.04.25

### DIFF
--- a/.azure-pipelines/run_docker_build.sh
+++ b/.azure-pipelines/run_docker_build.sh
@@ -5,7 +5,7 @@
 # changes to this script, consider a proposal to conda-smithy so that other feedstocks can also
 # benefit from the improvement.
 
-set -xeuo pipefail
+set -xeo pipefail
 
 THISDIR="$( cd "$( dirname "$0" )" >/dev/null && pwd )"
 PROVIDER_DIR="$(basename $THISDIR)"
@@ -28,12 +28,25 @@ fi
 ARTIFACTS="$FEEDSTOCK_ROOT/build_artifacts"
 
 if [ -z "$CONFIG" ]; then
-    echo "Need to set CONFIG env variable"
+    set +x
+    FILES=`ls .ci_support/linux_*`
+    CONFIGS=""
+    for file in $FILES; do
+        CONFIGS="${CONFIGS}'${file:12:-5}' or ";
+    done
+    echo "Need to set CONFIG env variable. Value can be one of ${CONFIGS:0:-4}"
     exit 1
 fi
 
-pip install shyaml
-DOCKER_IMAGE=$(cat "${FEEDSTOCK_ROOT}/.ci_support/${CONFIG}.yaml" | shyaml get-value docker_image.0 condaforge/linux-anvil-comp7 )
+if [ -z "${DOCKER_IMAGE}" ]; then
+    SHYAML_INSTALLED="$(shyaml --version || echo NO)"
+    if [ "${SHYAML_INSTALLED}" == "NO" ]; then
+        echo "WARNING: DOCKER_IMAGE variable not set and shyaml not installed. Falling back to condaforge/linux-anvil-comp7"
+        DOCKER_IMAGE="condaforge/linux-anvil-comp7"
+    else
+        DOCKER_IMAGE="$(cat "${FEEDSTOCK_ROOT}/.ci_support/${CONFIG}.yaml" | shyaml get-value docker_image.0 condaforge/linux-anvil-comp7 )"
+    fi
+fi
 
 mkdir -p "$ARTIFACTS"
 DONE_CANARY="$ARTIFACTS/conda-forge-build-done-${CONFIG}"


### PR DESCRIPTION
OSX was not uploaded on master on the last PR merge. Using this as a motiviation to rerender this recipe.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a fork of the feedstock to propose changes
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
