### PR TITLE
rely on run-exports, and properly disable iconv

### DIFF
--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -39,6 +39,9 @@ target_platform:
 - linux-64
 xz:
 - '5.2'
+zip_keys:
+- - cdt_name
+  - docker_image
 zlib:
 - '1.2'
 zstd:

--- a/.ci_support/osx_arm64_.yaml
+++ b/.ci_support/osx_arm64_.yaml
@@ -7,7 +7,7 @@ c_compiler:
 c_compiler_version:
 - '11'
 channel_sources:
-- conda-forge/label/rust_dev,conda-forge
+- conda-forge
 channel_targets:
 - conda-forge main
 libiconv:

--- a/.ci_support/win_64_.yaml
+++ b/.ci_support/win_64_.yaml
@@ -6,8 +6,6 @@ channel_sources:
 - conda-forge,defaults
 channel_targets:
 - conda-forge main
-libiconv:
-- '1.16'
 libxml2:
 - '2.9'
 lz4_c:
@@ -19,8 +17,6 @@ openssl:
 pin_run_as_build:
   bzip2:
     max_pin: x
-  libiconv:
-    max_pin: x.x
   libxml2:
     max_pin: x.x
   lz4-c:

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,11 +1,17 @@
 #!/bin/bash
 
+if [[ $target_platform =~ linux.* ]]; then
+    USE_ICONV=--without-iconv
+else
+    USE_ICONV=--with-iconv
+fi
+
 autoreconf -vfi
 mkdir build-${HOST} && pushd build-${HOST}
 ${SRC_DIR}/configure --prefix=${PREFIX}  \
                      --with-zlib         \
                      --with-bz2lib       \
-                     --with-iconv        \
+                     ${USE_ICONV}        \
                      --with-lz4          \
                      --with-lzma         \
                      --with-lzo2         \

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -46,16 +46,6 @@ requirements:
   host:
     - msinttypes  # [win and vc<14]
     - bzip2
-    - libiconv    # [not linux]
-    - lz4-c
-    - xz
-    - lzo
-    - openssl
-    - libxml2
-    - zlib
-    - zstd
-  run:
-    - bzip2
     - libiconv    # [osx]
     - lz4-c
     - xz


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->

I keep running into issues with libiconv with mamba and I think libarchive accidentally links to host libiconv on linux ... 

https://github.com/fastai/fastconda/runs/1706271326?check_suite_focus=true


Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
